### PR TITLE
Made UTF-8 default encoding by explicitly setting it

### DIFF
--- a/jvm/src/main/scala/edu/holycross/shot/ohco2/CorpusSource.scala
+++ b/jvm/src/main/scala/edu/holycross/shot/ohco2/CorpusSource.scala
@@ -19,7 +19,7 @@ object CorpusSource {
   * @param delimiter String value of column delimiter.
   */
   def fromFile(f: String, delimiter: String = "#"): Corpus = {
-    val stringPairs = Source.fromFile(f).getLines.toVector.filter(_.nonEmpty).map(_.split(delimiter))
+    val stringPairs = Source.fromFile(f, "UTF-8").getLines.toVector.filter(_.nonEmpty).map(_.split(delimiter))
     val citableNodes = stringPairs.map( arr => CitableNode(CtsUrn(arr(0)), arr(1)))
     Corpus(citableNodes)
   }

--- a/jvm/src/main/scala/edu/holycross/shot/ohco2/TextRepositorySource.scala
+++ b/jvm/src/main/scala/edu/holycross/shot/ohco2/TextRepositorySource.scala
@@ -23,7 +23,7 @@ object TextRepositorySource {
   * of CEX data.
   */
   def fromCexFile(cexFile: String, delimiter: String = "#"): TextRepository = {
-    TextRepository(Source.fromFile(cexFile).getLines.toVector.mkString("\n"))
+    TextRepository(Source.fromFile(cexFile, "UTF-8").getLines.toVector.mkString("\n"))
   }
 
   /** Convert an online text documented by an [[OnlineDocument]]
@@ -47,7 +47,7 @@ object TextRepositorySource {
   * @param outputDelim Delimiter to use in CEX output.
   */
   def cexForXml(doc: OnlineDocument, outputDelim: String = "#"): String = {
-    val xml = Source.fromFile(doc.docName).getLines.mkString("\n")
+    val xml = Source.fromFile(doc.docName, "UTF-8").getLines.mkString("\n")
     val corpus = SimpleTabulator(doc.urn, XPathTemplate(doc.xpathTemplate.get), xml)
     corpus.to2colString(outputDelim)
   }
@@ -103,7 +103,7 @@ object TextRepositorySource {
     delimiter1: String = "#",
     delimiter2: String = ","
   ): Vector[OnlineDocument] = {
-    val lines = Source.fromFile(configFileName).getLines.toVector.drop(1)
+    val lines = Source.fromFile(configFileName, "UTF-8").getLines.toVector.drop(1)
     val docs = lines.map(OnlineDocument(_, delimiter1, delimiter2)).toVector
     docs.map(_.absolutePath(baseDirectoryName))
   }
@@ -124,7 +124,7 @@ object TextRepositorySource {
     delimiter: String = "#",
     delimiter2 : String = ","): TextRepository = {
 
-    val catalogText = Source.fromFile(catalogFileName).getLines.mkString("\n")
+    val catalogText = Source.fromFile(catalogFileName, "UTF-8").getLines.mkString("\n")
     val catalog = Catalog(catalogText, delimiter)
 
     val onlineVect = TextRepositorySource.onlineVector(configFileName, baseDirectoryName)

--- a/jvm/src/test/scala/edu/holycross/shot/ohco2/CorpusSourceSpec.scala
+++ b/jvm/src/test/scala/edu/holycross/shot/ohco2/CorpusSourceSpec.scala
@@ -75,7 +75,7 @@ urn:cts:greekLit:tlg0016.tlg001.grc:#xml#test-hdt-grc.xml#tei->http://www.tei-c.
     val corpus = CorpusSource.fromFile(srcFile,"\t")
     val testFileName = "jvm/src/test/resources/test82xf.txt"
     CorpusSource.to82xfFile(corpus, testFileName, "#")
-    val outputLines = Source.fromFile(testFileName).getLines.toVector
+    val outputLines = Source.fromFile(testFileName, "UTF-8").getLines.toVector
     assert (outputLines.size == 10)
     val testFile = new File(testFileName)
     testFile.delete()
@@ -85,7 +85,7 @@ urn:cts:greekLit:tlg0016.tlg001.grc:#xml#test-hdt-grc.xml#tei->http://www.tei-c.
     val corpus = CorpusSource.fromFile(srcFile,"\t")
     val testFile = new File("jvm/src/test/resources/test82xf.txt")
     CorpusSource.to82xfFile(corpus, testFile, "#")
-    val outputLines = Source.fromFile(testFile).getLines.toVector
+    val outputLines = Source.fromFile(testFile, "UTF-8").getLines.toVector
     assert (outputLines.size == 10)
     testFile.delete()
   }
@@ -95,7 +95,7 @@ urn:cts:greekLit:tlg0016.tlg001.grc:#xml#test-hdt-grc.xml#tei->http://www.tei-c.
     val corpus = CorpusSource.fromFile(srcFile,"\t")
     val testFileName = "jvm/src/test/resources/test82xf.txt"
     CorpusSource.to2colFile(corpus,testFileName, "#")
-    val outputLines = Source.fromFile(testFileName).getLines.toVector
+    val outputLines = Source.fromFile(testFileName, "UTF-8").getLines.toVector
     assert (outputLines.size == 10)
     val testFile = new File(testFileName)
     testFile.delete()
@@ -106,7 +106,7 @@ urn:cts:greekLit:tlg0016.tlg001.grc:#xml#test-hdt-grc.xml#tei->http://www.tei-c.
     val testFileName = "jvm/src/test/resources/test82xf.txt"
     val testFile = new File(testFileName)
     CorpusSource.to2colFile(corpus,testFile, "#")
-    val outputLines = Source.fromFile(testFileName).getLines.toVector
+    val outputLines = Source.fromFile(testFileName, "UTF-8").getLines.toVector
     assert (outputLines.size == 10)
 
     testFile.delete()


### PR DESCRIPTION
As a response to issue #120 I explicitly set "utf-8" as default encoding everywhere where `Source.fromFile` is being used. This should go a long way towards fixing a common Windows bug.